### PR TITLE
Feature/short urls

### DIFF
--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -471,11 +471,12 @@ class GifDrop_Plugin {
 	 */
 	public function only_some_attachment_fields( &$attachment ) {
 		$full = wp_get_attachment_image_src( $attachment->ID, 'full' );
+		$short_url = home_url() . '/' . basename( $full[0] );
 		$static = wp_get_attachment_image_src( $attachment->ID, 'full-gif-static' );
 		$attachment = (object) array(
 			'id' => $attachment->ID,
-			'src' => $full[0],
-			'static' => $static ? $static[0] : $full[0],
+			'src' => $short_url,
+			'static' => $static ? $static[0] : $short_url,
 			'width' => $full[1],
 			'height' => $full[2],
 			'title' => $attachment->post_title,

--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -476,7 +476,7 @@ class GifDrop_Plugin {
 	public function only_some_attachment_fields( &$attachment ) {
 		$full = wp_get_attachment_image_src( $attachment->ID, 'full' );
 		$short_url = str_replace( 'wp-content/uploads/gifdrop/', '', $full[0] );
-		$url = ! empty( $this->get_option( 'shorturls' ) ) ? $short_url : $full[0];
+		$url = $this->get_option( 'shorturls' ) ? $short_url : $full[0];
 		$static = wp_get_attachment_image_src( $attachment->ID, 'full-gif-static' );
 		$attachment = (object) array(
 			'id' => $attachment->ID,

--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -622,6 +622,12 @@ class GifDrop_Plugin {
 		}
 
 		$endpoint = $_SERVER['REQUEST_URI'];
+
+		//  bail if we're in the root
+		if ( '/' == $endpoint ) {
+			return;
+		}
+
 		$upload_dir = wp_upload_dir();
 		$gifdrop_dir = trailingslashit( $upload_dir['basedir'] ) . 'gifdrop';
 

--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -48,6 +48,7 @@ class GifDrop_Plugin {
 		add_action( 'root_rewrite_rules', array( $this, 'inject_rewrite_rules' ), 99 );
 		add_action( 'plugin_row_meta', array( $this, 'plugin_row_meta' ), 20, 2 );
 		add_filter( 'plugin_action_links_' . plugin_basename($this->__FILE__), array( $this, 'plugin_action_links' ) );
+		add_action( 'wp', array( $this, 'redirect_short_url' ) );
 	}
 
 	/**
@@ -609,5 +610,27 @@ class GifDrop_Plugin {
 	public function plugin_action_links( $links ) {
 		$links[] = '<a href="'. $this->admin_url() .'">' . __( 'Settings', 'gifdrop' ) . '</a>';
 		return $links;
+	}
+
+	/**
+	 * Checks the existence of a given file by the path and redirects to the full url
+	 */
+	public function redirect_short_url() {
+		// bail if we're in the admin
+		if ( is_admin() ) {
+			return;
+		}
+
+		$endpoint = $_SERVER['REQUEST_URI'];
+		$upload_dir = wp_upload_dir();
+		$gifdrop_dir = trailingslashit( $upload_dir['basedir'] ) . 'gifdrop';
+
+		// bail if the file doesn't exist
+		if ( ! file_exists( $gifdrop_dir . $endpoint ) ) {
+			return;
+		}
+
+		wp_redirect( trailingslashit( $upload_dir['baseurl'] ) . 'gifdrop' . $endpoint );
+		exit;
 	}
 }

--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -629,6 +629,7 @@ class GifDrop_Plugin {
 			return;
 		}
 
+		// TODO: Make an option to use short urls (or not)
 		$upload_dir = wp_upload_dir();
 		$gifdrop_dir = trailingslashit( $upload_dir['basedir'] ) . 'gifdrop/';
 

--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -426,6 +426,10 @@ class GifDrop_Plugin {
 			$this->update_path( $_post['gifdrop_path'] );
 		}
 
+		// handle short url setting
+		$shorturls = ! empty( $_post['gifdrop_shorturls'] ) ? 1 : '';
+		$this->set_option( 'shorturls', $shorturls );
+
 		wp_redirect( $this->admin_url() . '&updated=true' );
 		exit;
 	}

--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -476,11 +476,12 @@ class GifDrop_Plugin {
 	public function only_some_attachment_fields( &$attachment ) {
 		$full = wp_get_attachment_image_src( $attachment->ID, 'full' );
 		$short_url = str_replace( 'wp-content/uploads/gifdrop/', '', $full[0] );
+		$url = ! empty( $this->get_option( 'shorturls' ) ) ? $short_url : $full[0];
 		$static = wp_get_attachment_image_src( $attachment->ID, 'full-gif-static' );
 		$attachment = (object) array(
 			'id' => $attachment->ID,
-			'src' => $short_url,
-			'static' => $static ? $static[0] : $short_url,
+			'src' => $url,
+			'static' => $static ? $static[0] : $url,
 			'width' => $full[1],
 			'height' => $full[2],
 			'title' => $attachment->post_title,

--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -630,14 +630,14 @@ class GifDrop_Plugin {
 		}
 
 		$upload_dir = wp_upload_dir();
-		$gifdrop_dir = trailingslashit( $upload_dir['basedir'] ) . 'gifdrop';
+		$gifdrop_dir = trailingslashit( $upload_dir['basedir'] ) . 'gifdrop/';
 
 		// bail if the file doesn't exist
-		if ( ! file_exists( $gifdrop_dir . $endpoint ) ) {
+		if ( ! file_exists( $gifdrop_dir . basename( $endpoint ) ) ) {
 			return;
 		}
 
-		wp_redirect( trailingslashit( $upload_dir['baseurl'] ) . 'gifdrop' . $endpoint );
+		wp_redirect( trailingslashit( $upload_dir['baseurl'] ) . 'gifdrop/' . basename( $endpoint ) );
 		exit;
 	}
 }

--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -471,7 +471,7 @@ class GifDrop_Plugin {
 	 */
 	public function only_some_attachment_fields( &$attachment ) {
 		$full = wp_get_attachment_image_src( $attachment->ID, 'full' );
-		$short_url = home_url() . '/' . basename( $full[0] );
+		$short_url = str_replace( 'wp-content/uploads/gifdrop/', '', $full[0] );
 		$static = wp_get_attachment_image_src( $attachment->ID, 'full-gif-static' );
 		$attachment = (object) array(
 			'id' => $attachment->ID,

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -30,7 +30,7 @@
 				<th scope="row"><label for="gifdrop-shorturls"><?php _e( 'Short URLs', 'gifdrop' ); ?></label></th>
 				<td class="gifdrop-use-short-urls-section">
 					<input type="checkbox" id="gifdrop-shorturls" name="gifdrop_shorturls" value="1" <?php checked( $this->get_option( 'shorturls', 1 ) ); ?> />
-					<p class="description"><?php echo sprintf( __( 'If enabled, image URLs will be shortened (e.g. %s).', 'gifdrop' ), home_url( 'xy.gif' ) ); ?></p>
+					<span class="description"><?php echo sprintf( __( 'If enabled, image URLs will be shortened (e.g. %s).', 'gifdrop' ), home_url( base_convert( absint( get_option( 'gifdrop_filename_count' ) ), 10, 36 ) . '.gif' ) ); ?></span>
 				</td>
 			</tr>
 		</table>

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -26,6 +26,13 @@
 					<p class="description"><?php _e( '(If this is blank, the front of your site will be your gif collection!)', 'gifdrop' ); ?></p>
 				</td>
 			</tr>
+			<tr valign="top">
+				<th scope="row"><label for="gifdrop-shorturls"><?php _e( 'Short URLs', 'gifdrop' ); ?></label></th>
+				<td class="gifdrop-use-short-urls-section">
+					<input type="checkbox" id="gifdrop-shorturls" name="gifdrop_shorturls" value="<?php echo esc_attr( $this->get_option( 'shorturls' ) ); ?>" />
+					<p class="description"><?php echo sprintf( __( 'If enabled, image URLs will be shortened (e.g. %s).', 'gifdrop' ), home_url( 'xy.gif' ) ); ?></p>
+				</td>
+			</tr>
 		</table>
 		<?php submit_button( __('Save Changes', 'gifdrop' ), 'primary', 'submit', true ); ?>
 	</form>

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -29,7 +29,7 @@
 			<tr valign="top">
 				<th scope="row"><label for="gifdrop-shorturls"><?php _e( 'Short URLs', 'gifdrop' ); ?></label></th>
 				<td class="gifdrop-use-short-urls-section">
-					<input type="checkbox" id="gifdrop-shorturls" name="gifdrop_shorturls" value="<?php echo esc_attr( $this->get_option( 'shorturls' ) ); ?>" />
+					<input type="checkbox" id="gifdrop-shorturls" name="gifdrop_shorturls" value="1" <?php checked( $this->get_option( 'shorturls', 1 ) ); ?> />
 					<p class="description"><?php echo sprintf( __( 'If enabled, image URLs will be shortened (e.g. %s).', 'gifdrop' ), home_url( 'xy.gif' ) ); ?></p>
 				</td>
 			</tr>


### PR DESCRIPTION
I love that you guys use a short, randomized string for the gif filenames. This branch builds on that to add an option that allows you to fully use short urls on a gifdrop repo, so, instead of mygifdrop.dev/wp-content/uploads/gifdrop/xY.gif you get mygifdrop.dev/xY.gif.
